### PR TITLE
Fix \underbar x typo

### DIFF
--- a/HAX606X-Optimisation-convexe/chapters/chapter1.tex
+++ b/HAX606X-Optimisation-convexe/chapters/chapter1.tex
@@ -112,9 +112,9 @@
 				\sup_{x\in K}|f(x)|<+\infty
 			\end{aligned}\]
 		
-		et il existe $\underbar x\in K$ et $\ol x\in K$ tels que 
+		et il existe $\underbar{$x$}\in K$ et $\ol x\in K$ tels que 
 			\[\begin{aligned}
-				f(\underbar x)&= \inf_{x\in K}f(x)=\min_{x\in K}f(x)\\
+				f(\underbar{$x$})&= \inf_{x\in K}f(x)=\min_{x\in K}f(x)\\
 				f(\ol x)&= \sup_{x\in K}f(x)=\max_{x\in K}f(x)\\
 			\end{aligned}\]
 	\end{oc-theorem}


### PR DESCRIPTION
Fixing "x" typo with underbar in math mode